### PR TITLE
Hexadecimal PID as a valid parameter

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -258,10 +258,10 @@ int main(int argc, char *argv[])
 			i++;
 		}
 		else if (!strcmp(param, PARAM_PID) && (i + 1) < argc) {
-			if (std::strncmp(argv[i + 1], "0x", 0) == 0) {
+			if (std::strncmp(argv[i + 1], "0x", 0) == 0 && (strlen(argv[i + 1]) > 2)) {
 				args.pid = std::stoul(argv[i + 1], nullptr, 16);
             		} else {
-                	args.pid = atoi(argv[i + 1]);
+                		args.pid = atoi(argv[i + 1]);
             		}
 			++i;
 		}

--- a/main.cpp
+++ b/main.cpp
@@ -258,7 +258,11 @@ int main(int argc, char *argv[])
 			i++;
 		}
 		else if (!strcmp(param, PARAM_PID) && (i + 1) < argc) {
-			args.pid = atoi(argv[i + 1]);
+			if (std::strncmp(argv[i + 1], "0x", 0) == 0) {
+				args.pid = std::stoul(argv[i + 1], nullptr, 16);
+            		} else {
+                	args.pid = atoi(argv[i + 1]);
+            		}
 			++i;
 		}
 		else if (!strcmp(param, PARAM_VERSION)) {


### PR DESCRIPTION
Small adjustement for permitting an hexadecimal PID as a valid parameter ("0x" format is mandatory), this could be useful, when some tools are showing the PID only in that way.