### PR TITLE
Add options for building a static library and linking statically

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,6 +3,7 @@ project (pe-sieve)
 
 option(PESIEVE_AS_DLL "Build PE-sieve as a DLL" OFF)
 option(PESIEVE_AS_STATIC_LIB "Build PE-Sieve as a static library" OFF)
+option(LINK_STATICALLY "Link PE-Sieve with static versions of linked libraries" OFF)
 
 include_directories (
   include
@@ -14,6 +15,12 @@ if("${CMAKE_C_COMPILER_ID}" STREQUAL "GNU")
 	)
 	add_compile_definitions(
 		_WIN32_WINNT=1536 # 0x600 aka Windows Vista required
+	)
+endif()
+
+if(LINK_STATICALLY)
+	add_link_options(
+		-static
 	)
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,17 +2,19 @@ cmake_minimum_required (VERSION 2.8)
 project (pe-sieve)
 
 option(PESIEVE_AS_DLL "Build PE-sieve as a DLL" OFF)
+option(PESIEVE_AS_STATIC_LIB "Build PE-Sieve as a static library" OFF)
+
 include_directories (
   include
 )
 
 if("${CMAKE_C_COMPILER_ID}" STREQUAL "GNU")
-    add_compile_options(
-        -fpermissive
-    )
-    add_compile_definitions(
-        _WIN32_WINNT=1536 # 0x600 aka Windows Vista required
-    )
+	add_compile_options(
+		-fpermissive
+	)
+	add_compile_definitions(
+		_WIN32_WINNT=1536 # 0x600 aka Windows Vista required
+	)
 endif()
 
 set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} /MT")
@@ -165,26 +167,43 @@ SOURCE_GROUP("Header Files\\postprocessors" FILES ${postprocessors_hdrs} )
 SOURCE_GROUP("Source Files\\postprocessors\\imp_rec" FILES ${imprec_srcs} )
 SOURCE_GROUP("Header Files\\postprocessors\\imp_rec" FILES ${imprec_hdrs} )
 
-# libs
-add_subdirectory (libpeconv/libpeconv)
-set ( PECONV_LIB $<TARGET_FILE:libpeconv> CACHE FILE "PEConvLib library path" )
+include(GNUInstallDirs)
+set (library_export_hdrs
+	include/pe_sieve_types.h
+	include/pe_sieve_version.h
+	include/pe_sieve_api.h
+)
+if(PESIEVE_AS_STATIC_LIB)
+	set(LIBRARY_TYPE STATIC)
+	# Install libpeconv as well since with static libraries a user has to link against both
+	set(PECONV_LIB_INSTALL ON CACHE INTERNAL "")
+elseif(PESIEVE_AS_DLL)
+	set(LIBRARY_TYPE SHARED)
+endif()
 
-# Choose to build the DLL or EXE
-
-if(PESIEVE_AS_DLL)
-	set (dll_hdrs
-		${hdrs}
-		include/pe_sieve_api.h
+# Choose to build the library or EXE
+if(PESIEVE_AS_STATIC_LIB OR PESIEVE_AS_DLL)
+	add_library ( ${PROJECT_NAME} ${LIBRARY_TYPE} ${library_export_hdrs} ${hdrs} ${srcs} dll_main.cpp main.def)
+	set_source_files_properties(main.def PROPERTIES HEADER_FILE_ONLY TRUE)
+	target_compile_definitions(${PROJECT_NAME} PUBLIC PESIEVE_${LIBRARY_TYPE}_LIB)
+	INSTALL(FILES ${library_export_hdrs}
+		DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}"
 	)
-	add_library ( ${PROJECT_NAME} SHARED ${dll_hdrs} ${srcs} dll_main.cpp main.def)
 	set_source_files_properties(main.def PROPERTIES HEADER_FILE_ONLY TRUE)
 else()
 	add_executable ( ${PROJECT_NAME} ${hdrs} ${srcs} ${rsrc} main.cpp )
 endif()
 
+install(TARGETS ${PROJECT_NAME}
+	ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+	LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+	RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
+
+# libs
+add_subdirectory (libpeconv/libpeconv)
+set ( PECONV_LIB $<TARGET_FILE:libpeconv> CACHE FILE "PEConvLib library path" )
+
 target_link_libraries ( ${PROJECT_NAME} ${PECONV_LIB} "psapi.lib" "ntdll.lib" "shlwapi")
 
 # dependencies
 add_dependencies(${PROJECT_NAME} libpeconv)
-
-INSTALL( TARGETS ${PROJECT_NAME} DESTINATION ${CMAKE_INSTALL_PREFIX} COMPONENT ${PROJECT_NAME} )

--- a/dll_main.cpp
+++ b/dll_main.cpp
@@ -9,7 +9,7 @@
 
 #define LIB_NAME "PE-sieve"
 
-pesieve::t_report __stdcall PESieve_scan(pesieve::t_params args)
+pesieve::t_report PESIEVE_API PESieve_scan(pesieve::t_params args)
 {
 	const pesieve::ReportEx* report = pesieve::scan_and_dump(args);
 	if (report == nullptr) {
@@ -23,7 +23,7 @@ pesieve::t_report __stdcall PESieve_scan(pesieve::t_params args)
 	return summary;
 }
 
-void __stdcall PESieve_help(void)
+void PESIEVE_API PESieve_help(void)
 {
 	std::string my_info = pesieve::info();
 
@@ -31,7 +31,7 @@ void __stdcall PESieve_help(void)
 	MessageBox(NULL, my_info.c_str(), LIB_NAME, MB_ICONINFORMATION);
 }
 
-DWORD __stdcall PESieve_version(void)
+DWORD PESIEVE_API PESieve_version(void)
 {
 	return pesieve::PESIEVE_VERSION_ID;
 }

--- a/include/pe_sieve_api.h
+++ b/include/pe_sieve_api.h
@@ -3,14 +3,33 @@
 #include <windows.h>
 #include "pe_sieve_types.h"
 
+#ifndef PESIEVE_STATIC_LIB
 #ifdef PESIEVE_EXPORTS
-#define PESIEVE_API __declspec(dllexport)
+#define PESIEVE_API __declspec(dllexport) __stdcall
 #else
-#define PESIEVE_API __declspec(dllimport)
+#define PESIEVE_API __declspec(dllimport) __stdcall
+#endif
+#else
+#define PESIEVE_API
 #endif
 
+#ifdef __cplusplus
 extern "C" {
-	void PESIEVE_API __stdcall PESieve_help(void);
-	DWORD PESIEVE_API __stdcall PESieve_version(void);
-	pesieve::t_report PESIEVE_API __stdcall PESieve_scan(pesieve::t_params args);
+#endif
+void PESIEVE_API PESieve_help(void);
+DWORD PESIEVE_API PESieve_version(void);
+
+#ifdef __cplusplus
+#define report_type pesieve::t_report
+#define params_type pesieve::t_params
+#else
+#define report_type t_report
+#define params_type t_params
+#endif
+report_type PESIEVE_API PESieve_scan(params_type args);
+#undef report_type
+#undef params_type
+
+#ifdef __cplusplus
 };
+#endif

--- a/include/pe_sieve_types.h
+++ b/include/pe_sieve_types.h
@@ -1,6 +1,5 @@
 #pragma once
 
-#include <vector>
 #include <windows.h>
 
 #include <pshpack4.h> // ensure 4 byte packing of the structures
@@ -8,7 +7,13 @@
 #define MAX_MODULE_BUF_LEN 1024
 #define PARAM_LIST_SEPARATOR ';'
 
+#ifndef __cplusplus
+typedef char bool;
+#endif
+
+#ifdef __cplusplus
 namespace pesieve {
+#endif
 	typedef enum {
 		OUT_FULL = 0,
 		OUT_NO_DUMPS,
@@ -69,6 +74,8 @@ namespace pesieve {
 		DWORD skipped; // some of the modules must be skipped (i.e. dotNET managed code have different characteristics and this scan does not apply)
 		DWORD errors; // errors prevented the scan
 	} t_report;
+#ifdef __cplusplus
 };
+#endif
 
 #include <poppack.h> //back to the previous structure packing

--- a/include/pe_sieve_version.h
+++ b/include/pe_sieve_version.h
@@ -2,10 +2,14 @@
 
 #include <windows.h>
 
+#ifdef __cplusplus
 namespace pesieve {
+#endif
 
 	static char PESIEVE_VERSION[] = "0.2.6.1";
 	static DWORD PESIEVE_VERSION_ID = 0x00020601; // 00 02 06 01
 	static char PESIEVE_URL[] = "https://github.com/hasherezade/pe-sieve";
 
+#ifdef __cplusplus
 };
+#endif


### PR DESCRIPTION
This pull request:
 - adds an option to build PE-Sieve as a static library
 - reworks the header files to support this feature and also to be C compatible
 - exports library headers and changes the export structure to GNU standard (possibly breaking change for build system? Might need to be discussed in detail)
 - adds an option to link against static versions of compiler libraries (useful for cross compiling since compiler libraries might not be available on the target)

One issue with the current implementation is that anyone linking against the static library needs to define PESIEVE_STATIC_LIB. One option to avoid this might be to export a pkgconfig file or something similar in the future which automatically sets this.


