### PR TITLE
Write scan_report in the base directory if /ofilter 1

### DIFF
--- a/pe_sieve.cpp
+++ b/pe_sieve.cpp
@@ -107,7 +107,7 @@ ProcessDumpReport* pesieve::dump_output(IN ProcessScanReport &process_report, IN
 	ProcessDumpReport* dumpReport = nullptr;
 	ResultsDumper dumper(expand_path(args.output_dir), args.quiet);
 
-	if (dumper.dumpJsonReport(process_report, ProcessScanReport::REPORT_SUSPICIOUS_AND_ERRORS) && !args.quiet) {
+	if (dumper.dumpJsonReport(process_report, ProcessScanReport::REPORT_SUSPICIOUS_AND_ERRORS, args.out_filter) && !args.quiet) {
 		std::cout << "[+] Report dumped to: " << dumper.getOutputDir() << std::endl;
 	}
 	size_t dumped_modules = 0;

--- a/postprocessors/results_dumper.cpp
+++ b/postprocessors/results_dumper.cpp
@@ -105,7 +105,7 @@ std::string get_module_file_name(HANDLE processHandle, const ModuleScanReport& m
 }
 //---
 
-bool ResultsDumper::dumpJsonReport(ProcessScanReport &process_report, const ProcessScanReport::t_report_filter &filter)
+bool ResultsDumper::dumpJsonReport(ProcessScanReport &process_report, const ProcessScanReport::t_report_filter &filter, const pesieve::t_output_filter &ofilter)
 {
 	std::stringstream stream;
 	size_t level = 1;
@@ -120,11 +120,24 @@ bool ResultsDumper::dumpJsonReport(ProcessScanReport &process_report, const Proc
 	if (report_all.length() == 0) {
 		return false;
 	}
-	//ensure that the directory is created:
-	this->dumpDir = ResultsDumper::makeDirName(process_report.getPid());
+
+	std::string report_path;
+
+	if ( ofilter != OUT_NO_DUMPS) {
+		//ensure that the directory is created:
+		this->dumpDir = ResultsDumper::makeDirName(process_report.getPid());
+		report_path = makeOutPath("scan_report.json");
+	}
+	else {
+		std::ostringstream ostream;
+		
+		ostream << process_report.getPid();
+		std::string pid = ostream.str();
+
+		report_path = this->baseDir + DIR_SEPARATOR + pid + "_scan_report.json";
+	}
 
 	std::ofstream json_report;
-	std::string report_path = makeOutPath("scan_report.json");
 	json_report.open(report_path);
 	if (json_report.is_open() == false) {
 		return false;

--- a/postprocessors/results_dumper.h
+++ b/postprocessors/results_dumper.h
@@ -18,7 +18,7 @@ public:
 	ProcessDumpReport* dumpDetectedModules(HANDLE hProcess, ProcessScanReport &process_report, const pesieve::t_dump_mode dump_mode, const pesieve::t_imprec_mode imprec_mode);
 
 	// dump JSON report from the process scan
-	bool dumpJsonReport(ProcessScanReport &process_report, const ProcessScanReport::t_report_filter &filter);
+	bool dumpJsonReport(ProcessScanReport &process_report, const ProcessScanReport::t_report_filter &filter, const pesieve::t_output_filter &ofilter);
 
 	bool dumpJsonReport(ProcessDumpReport &process_report);
 


### PR DESCRIPTION
Hello,

from my opinion, it's more user friendly to have all the scan_report.json in the base directory directly and prefixed with pid if /ofilter equal 1. 
Each report directories by pid are no longer created.

Maybe if this behaviour breaks the workflow too much, I can add another command line option instead.

Regards,