### PR TITLE
[BUGFIX] Add missing header include for MinGW

### DIFF
--- a/utils/strings_util.cpp
+++ b/utils/strings_util.cpp
@@ -1,6 +1,7 @@
 #include "strings_util.h"
 
 #include <algorithm>
+#include <cstring>
 
 std::string pesieve::util::to_lowercase(std::string str)
 {


### PR DESCRIPTION
Add an include that MinGW requires for strlen.