### PR TITLE
Include cmath in entropy.h

### DIFF
--- a/stats/entropy.h
+++ b/stats/entropy.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <cmath>
 #include <map>
 namespace pesieve {
 


### PR DESCRIPTION
The `log` function in `entropy.h` is used to calculate the Shannon Entropy. Without this `include`, PE-Sieve will not compile under MinGW on Linux due to the `log` function being undefined.